### PR TITLE
解决在 Windows 上还有部分文件乱码的问题

### DIFF
--- a/content/api/window.htm
+++ b/content/api/window.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
   </head>
 <body>

--- a/content/behaviors/scrollbar.htm
+++ b/content/behaviors/scrollbar.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <meta name="generator" content="h-smile:richtext"/>
   </head>

--- a/content/css/css-media-queries.htm
+++ b/content/css/css-media-queries.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>H-SMILE中的媒体查询</title> 
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/css/css-transition-sciter.htm
+++ b/content/css/css-transition-sciter.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>CSS属性 - transition</title>
   </head>

--- a/content/preface.htm
+++ b/content/preface.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <meta name="generator" content="behavior:richtext"/>
   </head>

--- a/content/sciter/Transact.htm
+++ b/content/sciter/Transact.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <meta name="generator" content="h-smile:richtext"/>
   </head>

--- a/content/script/Date.htm
+++ b/content/script/Date.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>Date对象</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/Float.htm
+++ b/content/script/Float.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>Float(浮点)对象</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/Function.htm
+++ b/content/script/Function.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>TIScript - Function(函数)对象</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/Index.htm
+++ b/content/script/Index.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>Index(索引)对象</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/Integer.htm
+++ b/content/script/Integer.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>Integer(整数)值</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/Math.htm
+++ b/content/script/Math.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <meta name="generator" content="h-smile:richtext"/>
   </head>

--- a/content/script/XMLScanner.htm
+++ b/content/script/XMLScanner.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>XMLScanner</title>
     <meta name="generator" content="h-smile:richtext"/>

--- a/content/script/language/Classes.htm
+++ b/content/script/language/Classes.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>>TIScript 3.2操作指南——类和名称空间</title>
     <link rel="stylesheet" href="for-screen.css"/>

--- a/content/script/language/Decorators.htm
+++ b/content/script/language/Decorators.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>TIScript 3.2操作指南——类和名称空间</title>
     <link rel="stylesheet" href="for-screen.css"/>

--- a/content/script/language/Functions.htm
+++ b/content/script/language/Functions.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>TIScript 3.2操作指南——函数</title>
     <link rel="stylesheet" href="for-screen.css"/>

--- a/content/script/language/for-screen.css
+++ b/content/script/language/for-screen.css
@@ -1,4 +1,4 @@
-  
+﻿  
   input#show-defintions
   {
     value-changed!: $1(body).hide-defintions = self:value ? null # true;

--- a/core/Better-CSS-sprites.htm
+++ b/core/Better-CSS-sprites.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>更好的CSS精灵</title>
 </head>
 

--- a/core/Caret-positions-in-HTML.htm
+++ b/core/Caret-positions-in-HTML.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>HTML中的插入位置</title>
 </head>
 
@@ -16,7 +17,8 @@ behavior:richtext行为时Sciter中<code>&lt;richtext&gt;</code>元素和Web浏�
 不过在Sciter2中，新的<code>behavior:richtext</code>行为使用标准的DOM模型，它的HTML内容为: element:node, text:node, comment:node。<br />
 这个变化导致我需要重新思考插入位置的概念。</p>
 <p>  考虑下面的标记代码:</p>
-<pre class="brush: html">&lt;p&gt;12&lt;b&gt;34&lt;/b&gt;&lt;i&gt;56&lt;/i&gt;&lt;/p&gt;</pre>
+<pre class="brush: html">&lt;p&gt;12&lt;b&gt;34&lt;/b&gt;&lt;i&gt;56&lt;/i&gt;&lt;/p&gt;
+</pre>
 <p>它的渲染结果如下: </p>
 <p>12<b>34</b><i>56</i></p>
 <p>问题来了: 在这个段落中有多少个插入位置?</p>

--- a/core/DOM-Inspector-how-remove-border-from-input.htm
+++ b/core/DOM-Inspector-how-remove-border-from-input.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>DOM检视器(Inspector), 如果移除输入元素的边框</title>
 </head>
 

--- a/core/Drag-and-Drop.htm
+++ b/core/Drag-and-Drop.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
  <head> 
   <title>Sciter中的内建的拖拽操作(Drag&Drop)</title> 
  </head> 

--- a/core/Formation.htm
+++ b/core/Formation.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
  <head> 
   <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" /> 
   <meta name="generator" content="h-smile:richtext" /> 

--- a/core/Object-match-feature.htm
+++ b/core/Object-match-feature.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
  <head> 
   <title>Sciter 3.2.0.3新增的对象匹配特性</title> 
  </head> 

--- a/core/Promises A+.htm
+++ b/core/Promises A+.htm
@@ -1,5 +1,7 @@
-<html>
-<head>
+﻿<html>
+
+<head>
+
 	<title>Sciter2中的Promises/A+ 实现</title>
 </head>
 

--- a/core/Sciter-3.htm
+++ b/core/Sciter-3.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 
 <head>
 	<title>Sciter 3</title>

--- a/core/Sciter-HTML-parsing-flavour.htm
+++ b/core/Sciter-HTML-parsing-flavour.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
 
 <head>
 	<title>Sciter中HTML的属性短格式写法</title>

--- a/core/Sciter-UI-application-architecture.htm
+++ b/core/Sciter-UI-application-architecture.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>Sciter UI, 应用程序框架</title>
 </head>
 

--- a/core/Sciter-on-multihead-system.htm
+++ b/core/Sciter-on-multihead-system.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>Sciter运行在不同监视器DPI设置的Windows 8.1系统的多屏系统上</title>
 </head>
 

--- a/core/Use-of-CSS-constants-in-script.htm
+++ b/core/Use-of-CSS-constants-in-script.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
  <head> 
   <title>在脚本中使用CSS常量</title> 
  </head> 

--- a/core/behavior-prototype-aspect.htm
+++ b/core/behavior-prototype-aspect.htm
@@ -1,5 +1,7 @@
-<html>
-<head>
+﻿<html>
+
+<head>
+
 	<title>Behavior与CSS中的prototype/aspect属性</title>
 </head>
 
@@ -38,7 +40,8 @@ div.some-widget { SomeWidget url(some-widget.tis); }</pre>
 <p>考虑上面的这些情况，我为Sciter引入了特有的CSS属性——&#8216;aspect&#8217;。</p>
 <h4>The <code>aspect</code> CSS property</h4>
 <p>它的声明为 </p>
-<pre>aspect: "函数名" [ url(of-function-implementation-file) ];
+<pre>
+aspect: "函数名" [ url(of-function-implementation-file) ];
 </pre>
 <p>其中，<code>"函数名"</code>是一个&#8220;aspect&#8221;函数的全名，指为DOM元素配置/装载额外功能的函数。 其中的<code>url()</code>是定义该函数的文件名。</p>
 <p>aspect处理原则:</p>

--- a/core/construction-mean-TIScript.htm
+++ b/core/construction-mean-TIScript.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>TIScript中的&#8220;::&#8221;构造器的含义是什么?</title>
 </head>
 

--- a/core/csss!-calc-function.htm
+++ b/core/csss!-calc-function.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>CSSS!中的calc()函数</title> 
     <meta name="generator" content="h-smile:richtext"/>

--- a/core/csss!-events.htm
+++ b/core/csss!-events.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>CSSS!事件</title> 
     <meta name="source"/>

--- a/core/csss!.htm
+++ b/core/csss!.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <title>CSSS!(CSS脚本)语言</title> 
     <meta name="generator" content="h-smile:richtext"/>

--- a/core/frame-content-style.htm
+++ b/core/frame-content-style.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   
   <head>
     <title>

--- a/core/new-TIScript-features.htm
+++ b/core/new-TIScript-features.htm
@@ -1,6 +1,7 @@
-<html>
+﻿<html>
 
-<head>
+<head>
+
 	<title>Sciter 2.0.2.0 发布了TIScript的一些新特性</title>
 </head>
 

--- a/core/specific-tags.htm
+++ b/core/specific-tags.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
  <head> 
   <title>Sciter特有的HTML标签</title> 
  </head> 

--- a/core/upcomming-changes-in-4.1.html
+++ b/core/upcomming-changes-in-4.1.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+﻿<!DOCTYPE html>
 <html>
   
   <head>

--- a/tiscript-article.htm
+++ b/tiscript-article.htm
@@ -1,4 +1,4 @@
-<html>
+﻿<html>
   <head>
     <meta name="generator" content="h-smile:richtext"/>
     <meta name="source"/>


### PR DESCRIPTION
解决在 Windows 上还有部分文件乱码的问题, 在 windows 上, 所有的文件无论是否 utf8 都需要加上 bom 头才能正常显示.